### PR TITLE
Provide a command to get items from a board without a sprint

### DIFF
--- a/cmd/board/board.go
+++ b/cmd/board/board.go
@@ -14,6 +14,7 @@ func NewBoardCommand(client jira.API) *cobra.Command {
 
 	cmd.AddCommand(
 		NewListCommand(client),
+		NewIssueCommand(client),
 	)
 	return cmd
 }

--- a/cmd/board/issues.go
+++ b/cmd/board/issues.go
@@ -1,0 +1,62 @@
+package board
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	goJira "github.com/andygrunwald/go-jira"
+	"github.com/benmatselby/walter/jira"
+	"github.com/spf13/cobra"
+)
+
+// NewIssueCommand creates a new `board issues` command
+func NewIssueCommand(client jira.API) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "issues",
+		Short: "List all the issues for the board",
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			err := ListIssues(client, args[0], os.Stdout)
+			if err != nil {
+				fmt.Print(err)
+				os.Exit(1)
+			}
+		},
+	}
+
+	return cmd
+}
+
+// ListIssues will list all the issues for a given board
+func ListIssues(client jira.API, boardName string, w io.Writer) error {
+	issues, err := client.GetIssuesForBoard(boardName)
+	if err != nil {
+		return err
+	}
+
+	items := make(map[string][]goJira.Issue)
+
+	// BoardColumn => Items[]
+	for index := 0; index < len(issues); index++ {
+		item := issues[index]
+
+		key := item.Fields.Status.Name
+		items[key] = append(items[key], item)
+	}
+
+	layout, err := client.GetBoardLayout(boardName)
+	if err != nil {
+		return err
+	}
+
+	for _, column := range layout {
+		fmt.Fprintf(w, "\n%s\n", column)
+		fmt.Fprintf(w, strings.Repeat("=", len(column))+"\n")
+		for _, v := range items[column] {
+			fmt.Fprintf(w, "* %s\n", v.Fields.Summary)
+		}
+	}
+	return nil
+}

--- a/cmd/board/issues_test.go
+++ b/cmd/board/issues_test.go
@@ -1,0 +1,86 @@
+package board_test
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"testing"
+
+	goJira "github.com/andygrunwald/go-jira"
+	"github.com/benmatselby/walter/cmd/board"
+
+	"github.com/benmatselby/walter/jira"
+	"github.com/golang/mock/gomock"
+)
+
+func TestNewIssueCommand(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := jira.NewMockAPI(ctrl)
+
+	cmd := board.NewIssueCommand(client)
+
+	use := "issues"
+	short := "List all the issues for the board"
+
+	if cmd.Use != use {
+		t.Fatalf("expected use: %s; got %s", use, cmd.Use)
+	}
+
+	if cmd.Short != short {
+		t.Fatalf("expected use: %s; got %s", short, cmd.Short)
+	}
+}
+
+func TestListIssues(t *testing.T) {
+	tt := []struct {
+		name   string
+		output string
+		err    error
+	}{
+		{name: "can return a list of issues", output: "\nTodo\n====\n* Issue 1\n", err: nil},
+		{name: "returns error if we cannot get list of issues", output: "", err: errors.New("something")},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			client := jira.NewMockAPI(ctrl)
+
+			fields := goJira.IssueFields{
+				Summary: "Issue 1",
+				Status:  &goJira.Status{Name: "Todo"},
+			}
+
+			jiraIssues := goJira.Issue{
+				Fields: &fields,
+			}
+
+			issues := make([]goJira.Issue, 0)
+			issues = append(issues, jiraIssues)
+
+			client.
+				EXPECT().
+				GetIssuesForBoard(gomock.Eq("board")).
+				Return(issues, tc.err).
+				AnyTimes()
+
+			client.
+				EXPECT().
+				GetBoardLayout(gomock.Eq("board")).
+				Return([]string{"Todo"}, tc.err).
+				AnyTimes()
+
+			var b bytes.Buffer
+			writer := bufio.NewWriter(&b)
+
+			board.ListIssues(client, "board", writer)
+			writer.Flush()
+
+			if b.String() != tc.output {
+				t.Fatalf("expected '%s'; got '%s'", tc.output, b.String())
+			}
+		})
+	}
+}

--- a/jira/mock_jira.go
+++ b/jira/mock_jira.go
@@ -109,6 +109,21 @@ func (mr *MockAPIMockRecorder) GetIssues(boardName, sprintName interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIssues", reflect.TypeOf((*MockAPI)(nil).GetIssues), boardName, sprintName)
 }
 
+// GetIssuesForBoard mocks base method
+func (m *MockAPI) GetIssuesForBoard(boardName string) ([]go_jira.Issue, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIssuesForBoard", boardName)
+	ret0, _ := ret[0].([]go_jira.Issue)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIssuesForBoard indicates an expected call of GetIssuesForBoard
+func (mr *MockAPIMockRecorder) GetIssuesForBoard(boardName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIssuesForBoard", reflect.TypeOf((*MockAPI)(nil).GetIssuesForBoard), boardName)
+}
+
 // GetIssueCustomFields mocks base method
 func (m *MockAPI) GetIssueCustomFields(issueID string) (go_jira.CustomFields, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Some projects in Jira do not have sprints, and therefore the `sprint
issues` command does not work.