### PR TITLE
Provide a "-v" mode for the `sprint list` command

### DIFF
--- a/cmd/sprint/list.go
+++ b/cmd/sprint/list.go
@@ -9,15 +9,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// ListSprintOptions defines the options available for listing the sprints
+type ListSprintOptions struct {
+	Args    []string
+	Verbose bool
+}
+
 // NewListCommand creates a new `sprint list` command
 func NewListCommand(client jira.API) *cobra.Command {
+	var opts ListSprintOptions
+
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "List all the sprints",
 		Example: "walter sprint list \"my board\"",
 		Args:    cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			err := ListSprints(client, args[0], os.Stdout)
+			opts.Args = args
+
+			err := ListSprints(client, opts, os.Stdout)
 			if err != nil {
 				fmt.Print(err)
 				os.Exit(1)
@@ -25,18 +35,29 @@ func NewListCommand(client jira.API) *cobra.Command {
 		},
 	}
 
+	flags := cmd.Flags()
+	flags.BoolVarP(&opts.Verbose, "verbose", "v", false, "Verbose output")
+
 	return cmd
 }
 
 // ListSprints will list all the sprints for a given board
-func ListSprints(client jira.API, boardName string, w io.Writer) error {
-	sprints, err := client.GetSprints(boardName)
+func ListSprints(client jira.API, opts ListSprintOptions, w io.Writer) error {
+	sprints, err := client.GetSprints(opts.Args[0])
 	if err != nil {
 		return err
 	}
 
 	for _, sprint := range sprints {
-		fmt.Fprintf(w, "%s\n", sprint.Name)
+		fmt.Fprintf(w, "%s", sprint.Name)
+		if opts.Verbose {
+			fmt.Fprintln(w)
+			fmt.Fprintf(w, " ID: %v\n", sprint.ID)
+			fmt.Fprintf(w, " Start date: %v\n", sprint.StartDate)
+			fmt.Fprintf(w, " End date: %v\n", sprint.EndDate)
+			fmt.Fprintf(w, " Completed date: %v\n", sprint.CompleteDate)
+		}
+		fmt.Fprintln(w)
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -18,3 +18,5 @@ require (
 	golang.org/x/sys v0.0.0-20190620070143-6f217b454f45 // indirect
 	golang.org/x/text v0.3.2 // indirect
 )
+
+go 1.13


### PR DESCRIPTION
Many of the widgets in Jira/Confluence require you to know the sprint
number. There may be a very simple way of finding that out, but it seems
long winded, so this change allows you to easily see the ID.