### PR TITLE
List all the boards within the Atlassian instance.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Bump the dependencies.
 - Run the GitHub actions on multiple versions of Go.
+- List all the boards, not just the limit of 50. Thanks to [Richard Neal](https://github.com/Richard-W-Neal) for raising.
+  - `walter board list`
+- Use the `Name` attribute to search for a single board, rather than pulling all boards back, and iterating over them, to find the match.
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## next
 
+## 2.2.1
+
 - Bump the dependencies.
 - Run the GitHub actions on multiple versions of Go.
 - List all the boards, not just the limit of 50. Thanks to [Richard Neal](https://github.com/Richard-W-Neal) for raising.

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -75,12 +75,13 @@ func (c *Client) GetBoards() ([]jira.Board, error) {
 
 // GetBoard will return a single board given a name
 func (c *Client) GetBoard(name string) (*jira.Board, error) {
-	list, err := c.GetBoards()
+	opts := &jira.BoardListOptions{Name: name}
+	list, _, err := c.jira.Board.GetAllBoards(opts)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, item := range list {
+	for _, item := range list.Values {
 		if item.Name == name {
 			return &item, nil
 		}

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -50,13 +50,24 @@ func (c *Client) IssueSearch(query string, opts *jira.SearchOptions) ([]jira.Iss
 
 // GetBoards will return the boards you can access
 func (c *Client) GetBoards() ([]jira.Board, error) {
-	opts := jira.BoardListOptions{}
-	list, _, err := c.jira.Board.GetAllBoards(&opts)
-	if err != nil {
-		return nil, err
+	var boards []jira.Board
+	start := 0
+	for {
+		search := jira.SearchOptions{StartAt: start}
+		opts := &jira.BoardListOptions{SearchOptions: search}
+		list, _, err := c.jira.Board.GetAllBoards(opts)
+		if err != nil {
+			return nil, err
+		}
+
+		start += len(list.Values)
+		boards = append(boards, list.Values...)
+
+		if list.IsLast {
+			break
+		}
 	}
 
-	boards := list.Values
 	sort.Slice(boards, func(i, j int) bool { return boards[i].Name < boards[j].Name })
 
 	return boards, nil


### PR DESCRIPTION
Before the fix, we were only bring back the first 50 results, which
wouldn't include everything. We now iterate over the result set.